### PR TITLE
Enable percentile histograms for HTTP metrics.

### DIFF
--- a/bidrag-aktoerregister/src/main/resources/application.yaml
+++ b/bidrag-aktoerregister/src/main/resources/application.yaml
@@ -28,6 +28,9 @@ springdoc:
   swagger-ui:
     path: /
 
+management.metrics.distribution.percentiles-histogram.http.server.requests: true
+management.metrics.distribution.percentiles-histogram.http.client.requests: true
+
 no.nav.security.jwt:
   client:
     registration:

--- a/bidrag-elin-stub/src/main/resources/application.yaml
+++ b/bidrag-elin-stub/src/main/resources/application.yaml
@@ -10,6 +10,8 @@ springdoc:
     path: /
 
 spring.main.banner-mode: off
+management.metrics.distribution.percentiles-histogram.http.server.requests: true
+management.metrics.distribution.percentiles-histogram.http.client.requests: true
 ---
 spring.config.activate.on-profile: nais,local
 no.nav.security.jwt:

--- a/bidrag-regnskap/src/main/resources/application.yaml
+++ b/bidrag-regnskap/src/main/resources/application.yaml
@@ -38,6 +38,9 @@ sftp:
   privateKey: ${SFTP_PRIVATE_KEY}
   skalOverforeFil: ${SFTP_SKAL_OVERFORE_FIL}
 
+management.metrics.distribution.percentiles-histogram.http.server.requests: true
+management.metrics.distribution.percentiles-histogram.http.client.requests: true
+
 spring.config.activate.on-profile: nais
 
 no.nav.security.jwt:

--- a/bidrag-reskontro-legacy/src/main/resources/application.yaml
+++ b/bidrag-reskontro-legacy/src/main/resources/application.yaml
@@ -11,6 +11,9 @@ springdoc:
     display-request-duration: true
     try-it-out-enabled: true
 
+management.metrics.distribution.percentiles-histogram.http.server.requests: true
+management.metrics.distribution.percentiles-histogram.http.client.requests: true
+
 spring.config.activate.on-profile: nais,lokal-nais
 
 no.nav.security.jwt:

--- a/bidrag-reskontro/src/main/resources/application.yaml
+++ b/bidrag-reskontro/src/main/resources/application.yaml
@@ -19,6 +19,9 @@ maskinporten:
   privateKey: ${MASKINPORTEN_CLIENT_JWK}
   validInSeconds: 120 #120 er maks antall sekunder et maskinporten Jwt-token kan være gyldig.
 
+management.metrics.distribution.percentiles-histogram.http.server.requests: true
+management.metrics.distribution.percentiles-histogram.http.client.requests: true
+
 spring.config.activate.on-profile: nais,lokal-nais
 
 no.nav.security.jwt:


### PR DESCRIPTION
Added configuration to collect percentile histograms for both server and client HTTP requests across multiple modules. This will improve observability and allow more detailed analysis of request latency and performance.