### PR TITLE
Starter transaksjonen for behandling av hendelser ett steg tidligere …

### DIFF
--- a/bidrag-regnskap/src/main/kotlin/no/nav/bidrag/regnskap/service/VedtakshendelseService.kt
+++ b/bidrag-regnskap/src/main/kotlin/no/nav/bidrag/regnskap/service/VedtakshendelseService.kt
@@ -15,6 +15,7 @@ import no.nav.bidrag.transport.behandling.vedtak.Engangsbeløp
 import no.nav.bidrag.transport.behandling.vedtak.Stønadsendring
 import no.nav.bidrag.transport.behandling.vedtak.VedtakHendelse
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 
 private val LOGGER = KotlinLogging.logger {}
@@ -31,6 +32,7 @@ class VedtakshendelseService(
     private val driftsavvikService: DriftsavvikService,
 ) {
 
+    @Transactional
     fun behandleHendelse(hendelse: String): List<Int> {
         if (driftsavvikService.harAktivtDriftsavvik(erInnlesing = true)) {
             throw PåløpException("Det finnes aktive driftsavvik som ikke tillater innlesing. Kan derfor ikke opprette oppdrag for vedtakshendelse.")


### PR DESCRIPTION
…så både opprettelse av engangsbeløp og stønadsendring er dekket av samme transaksjon. Dette er nødvendig for at vi skal rulle tilbake hele hendelsen om en av disse to (egentlig bare engangsbeløp da den behandles sist) feiler. Om vi ikke gjør dette vil stønadsendringen bli opprettet i databasen, men engangsbeløpet ikke og hendelsen ikke konsumert. Ved rekjøring da av hendelse vil da det enten feile (om stønadsendring er sendt med en delytelsesId fra Bisys) eller lage et unødvendig duplikat. Duplikatet vil ikke ha noe å si da det blir en korreksjon på samme hendelse, men fører til unødvendige konteringer som vi kunne unngått.